### PR TITLE
Possible fix for postgame thread tight loop bug

### DIFF
--- a/bots/lemmy_mlb_game_threads/__init__.py
+++ b/bots/lemmy_mlb_game_threads/__init__.py
@@ -2247,7 +2247,7 @@ Last Updated: """ + self.convert_timezone(
                         self.commonData[pk]["schedule"]["status"]["codedGameState"],
                     )
                 )
-                self.sleep(60)
+            self.sleep(60)
 
         if redball.SIGNAL is not None or self.bot.STOP:
             self.log.debug("Caught a stop signal...")


### PR DESCRIPTION
Move sleep from else case so that it will keep the while loop from starving the CPU.