### PR TITLE
Sticky cleanup 5

### DIFF
--- a/bots/lemmy_mlb_game_threads/__init__.py
+++ b/bots/lemmy_mlb_game_threads/__init__.py
@@ -962,7 +962,7 @@ class Bot(object):
                     }
                 )
                 # Only sticky when posting the thread
-                if self.settings.get("Reddit", {}).get("STICKY", False):
+                if self.settings.get("Lemmy", {}).get("STICKY", False):
                     self.sticky_thread(offDayThread)
 
         if not offDayThread:
@@ -1237,7 +1237,7 @@ Last Updated: """
                     }
                 )
                 # Only sticky when posting the thread
-                if self.settings.get("Reddit", {}).get("STICKY", False):
+                if self.settings.get("Lemmy", {}).get("STICKY", False):
                     self.sticky_thread(gameDayThread)
 
         # Check if post game thread is already posted, and skip game day thread if so
@@ -2263,7 +2263,7 @@ Last Updated: """ + self.convert_timezone(
                     }
                 )
                 # Only sticky when posting the thread
-                if self.settings.get("Reddit", {}).get("STICKY", False):
+                if self.settings.get("Lemmy", {}).get("STICKY", False):
                     self.sticky_thread(self.activeGames[pk]["postGameThread"])
 
         game_result = (
@@ -5442,9 +5442,7 @@ Last Updated: """ + self.convert_timezone(
     def mark_thread_stale(self, ttype, thread):
         # Schedule thread for deferred processing
         # (Currently just unstickys it)
-        if self.settings.get("Lemmy", {}).get("STICKY", False) or self.settings.get(
-            "Reddit", {}
-        ).get("STICKY", False):
+        if self.settings.get("Lemmy", {}).get("STICKY", False):
             if (
                 self.activeGames.get(ttype, {}).get(thread)
                 and self.activeGames[ttype][thread] not in self.staleThreads

--- a/bots/lemmy_mlb_game_threads/__init__.py
+++ b/bots/lemmy_mlb_game_threads/__init__.py
@@ -37,7 +37,9 @@ POST_DT_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
 MLB_DT_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 
-def LINE():
+def caller_line():
+    # Current frame is this function, first back is for function
+    # being debugged, second back is for the caller of that function.
     return currentframe().f_back.f_back.f_lineno
 
 
@@ -5428,7 +5430,7 @@ Last Updated: """ + self.convert_timezone(
         return ""
 
     def sticky_thread(self, thread):
-        self.log.info("{LINE()}-Stickying thread [{}]...".format(thread["post"]["id"]))
+        self.log.info("Stickying thread [{}]...".format(thread["post"]["id"]))
         try:
             self.lemmy.stickyPost(thread["post"]["id"])
             self.log.info("Thread [{}] stickied...".format(thread["post"]["id"]))
@@ -5448,12 +5450,12 @@ Last Updated: """ + self.convert_timezone(
                 and self.activeGames[ttype][thread] not in self.staleThreads
             ):
                 self.log.info(
-                    f"({LINE()}-Marking {thread} ({self.activeGames[ttype][thread]['post']['id']}) stale."
+                    f"({caller_line()}-Marking {thread} ({self.activeGames[ttype][thread]['post']['id']}) stale."
                 )
                 self.staleThreads.append(self.activeGames[ttype][thread])
             else:
                 tt_info = self.activeGames.get(ttype, f"No record for {ttype}")
-                self.log.info(f"{LINE()}-Unable to mark {thread} stale: [ {tt_info} ]")
+                self.log.info(f"{caller_line()}-Unable to mark {thread} stale: [ {tt_info} ]")
             self.log.info(f"staleThreads: {self.staleThreads}")
 
     def process_stale_threads(self):
@@ -5464,7 +5466,7 @@ Last Updated: """ + self.convert_timezone(
         #
         # Currently this function just unstickys stale threads
         self.log.info(
-            f"{LINE()}-Processing {len(self.staleThreads)} stale threads: {self.staleThreads}"
+            f"{caller_line()}-Processing {len(self.staleThreads)} stale threads: {self.staleThreads}"
         )
         for t in self.staleThreads:
             self.unsticky_thread(t)

--- a/bots/lemmy_mlb_game_threads/__init__.py
+++ b/bots/lemmy_mlb_game_threads/__init__.py
@@ -5478,7 +5478,7 @@ Last Updated: """ + self.convert_timezone(
                     and
                     "weeekly" not in p['post']['name'].lower()
                     and
-                    datetime.strptime(p['post']['published'], POST_DT_FORMAT).date() < datetime.utcnow().date()
+                    self.convert_timezone(datetime.strptime(p['post']['published'], POST_DT_FORMAT), self.myTeam["venue"]["timeZone"]["id"]).date() < self.convert_timezone(datetime.utcnow(), self.myTeam["venue"]["timeZone"]["id"]).date()
             ):
 
                 self.log.warning(f'Post #{p["post"]["id"]} was left sticky yesterday.')


### PR DESCRIPTION
Fixes #9.

Started by reducing a bunch of the copied logic to a couple of functions.  Then I discovered that the timing of the stale thread processing could be tricky, so I decided to move it to its own thread.  This thread also checks for sticky threads at the end of the day and cleans them up.  (It throws a warning if a thread is unticked without being requested to do so)

Also added constants for the DT strings, and ran black.